### PR TITLE
update how inputs are passed to ensure all new props are forwarded as…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ The loading recommendation for each third-party resource is defined with the fol
   website?: string;
   html?: {
     element: string;
-    attributes: HtmlAttributes;
+    attributes: {
+      [string]?: string,
+      src?: {
+        url: string;
+        slugParam: string;
+        params: Array<string>;  
+      }
+    };
   };
   stylesheets?: Array<string>;
   scripts?: Array<{
@@ -45,10 +52,14 @@ These properties provide a heuristic for consumers to decide how, when, and wher
 - **id** _(required)_: Identifier string
 - **description** _(required)_: Short description of third-party entity
 - **website** _(optional)_: URL address of website
-- **html** _(optional<sup>\*</sup>)_: HTML element to be inserted where 3PC component is placed. The `attributes` property allows you to include a list of default or user-required attributes and their values.
+- **html** _(optional<sup>\*</sup>)_: HTML element to be inserted where 3PC component is placed. The `attributes` property allows you to include a list of any default attributes and their values which will be overwritten if the user specifies a different value. The `src` attribute is the only property that needs to follow a specific structure:
+  - **url**: The URL of the resource
+  - **slugParam**: The name of the parameter that is used the user to either include or replace the slug of the URL
+  - **params**: An array of parameter names that when used as arguments by the user are assigned as query parameters to the URL
 - **stylesheets** _(optional<sup>\*</sup>)_: URLs of any stylesheets that need to be loaded
 - **scripts** _(optional<sup>\*</sup>)_: URLs of any scripts that need to be loaded, either as an array of URLs or an object array that contains a list of the following properties:
-  - **url**: URL of script with or without any user-required parameters
+  - **url**: The URL of script
+  - **params**: An array of parameter names that when used as arguments by the user are assigned as query parameters to the URL
   - **strategy**: String literal to denote loading strategy of third-party script (on the server, on the client, during browser idle time, or in a web worker)
   - **location**: String literal to denote whether to inject the script in <head> or <body> (only useful if strategy=server is used)
   - **action**: String literal to denote whether to prepend or append the script (only useful if strategy=server is used)

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -9,7 +9,8 @@
     "allowJs": true,
     "declaration": true,
     "declarationMap": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "suppressImplicitAnyIndexErrors": true
   },
   "files": ["../src/index.ts"]
 }

--- a/src/third-parties/google-maps-embed/data.json
+++ b/src/third-parties/google-maps-embed/data.json
@@ -8,6 +8,7 @@
       "loading": "lazy",
       "src": {
         "url": "https://www.google.com/maps/embed/v1/place",
+        "slugParam": "mode",
         "params": [
           "key",
           "q",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ type ScriptLocation = 'head' | 'body';
 type ScriptAction = 'append' | 'prepend';
 export type SrcVal = {
   url: string;
+  slugParam?: string;
   params?: Array<string>;
 };
 

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -102,14 +102,14 @@ describe('Utils', () => {
       };
 
       const inputs = {
-        id: '123',
+        id: 'props.id',
         loading: 'auto',
         width: '150',
       };
 
       const result = formatData(data, inputs);
       expect(result.html).toEqual(
-        '<iframe loading="auto" src="https://www.example.com/?id=123" width="150" height="100"></iframe>',
+        '<iframe loading="auto" src="https://www.example.com/?id=props.id" width="150" height="100"></iframe>',
       );
       expect(result.scripts).toEqual(null);
     });
@@ -136,14 +136,16 @@ describe('Utils', () => {
       };
 
       const inputs = {
-        id: '123',
+        id: 'userDefinedId',
       };
 
       const result = formatData(data as Data, inputs);
       expect(result.html).toEqual('<iframe loading="lazy"></iframe>');
       expect(result.scripts).not.toEqual(null);
       expect(result.scripts!.length).toEqual(1);
-      expect(result.scripts![0].url).toEqual('https://www.example.com/?id=123');
+      expect(result.scripts![0].url).toEqual(
+        'https://www.example.com/?id=userDefinedId',
+      );
     });
 
     it('should forward all additional inputs as html attributes if not used elsewhere', () => {
@@ -161,14 +163,14 @@ describe('Utils', () => {
       };
 
       const inputs = {
-        id: '123',
+        id: 'props.id',
         loading: 'auto',
         width: '150',
       };
 
       const result = formatData(data, inputs);
       expect(result.html).toEqual(
-        '<iframe loading="auto" width="150" height="100" id="123"></iframe>',
+        '<iframe loading="auto" width="150" height="100" id="props.id"></iframe>',
       );
       expect(result.scripts).toEqual(null);
     });

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -172,5 +172,61 @@ describe('Utils', () => {
       );
       expect(result.scripts).toEqual(null);
     });
+
+    it('should include the user inputted slug to the src URL if provided as a parameter', () => {
+      const data = {
+        id: 'third-party',
+        description: 'Description',
+        html: {
+          element: 'iframe',
+          attributes: {
+            loading: 'lazy',
+            src: {
+              url: 'https://www.example.com/',
+              slugParam: 'inputSlug',
+            },
+          },
+        },
+      };
+
+      const inputs = {
+        inputSlug: 'cool-slug',
+      };
+
+      const result = formatData(data, inputs);
+      expect(result.html).toEqual(
+        '<iframe loading="lazy" src="https://www.example.com/cool-slug"></iframe>',
+      );
+      expect(result.scripts).toEqual(null);
+    });
+
+    it('should replace the already existing slug if the user includes a slug parameter slug', () => {
+      const data = {
+        id: 'third-party',
+        description: 'Description',
+        html: {
+          element: 'iframe',
+          attributes: {
+            loading: 'lazy',
+            src: {
+              url: 'https://www.google.com/maps/embed/v1/place',
+              slugParam: 'mode',
+              params: ['key'],
+            },
+          },
+        },
+      };
+
+      const inputs = {
+        mode: 'view',
+        key: '123',
+      };
+
+      const result = formatData(data, inputs);
+      expect(result.html).toEqual(
+        '<iframe loading="lazy" src="https://www.google.com/maps/embed/v1/view?key=123"></iframe>',
+      );
+      expect(result.scripts).toEqual(null);
+    });
   });
 });

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,4 +1,5 @@
-import { formatUrl, createHtml } from '.';
+import { formatUrl, createHtml, formatData } from '.';
+import type { Data } from '../types';
 
 describe('Utils', () => {
   describe('formatUrl', () => {
@@ -25,12 +26,12 @@ describe('Utils', () => {
 
     it('should construct a HTML element with default attributes and values', () => {
       const element = 'lite-element';
-      const attrs = {
+      const defaultAttrs = {
         id: '123',
         loading: 'lazy',
       };
 
-      const htmlElement = createHtml(element, attrs);
+      const htmlElement = createHtml(element, defaultAttrs);
       expect(htmlElement).toEqual(
         '<lite-element id="123" loading="lazy"></lite-element>',
       );
@@ -38,19 +39,24 @@ describe('Utils', () => {
 
     it('should construct a HTML element passing parameters to any required src URLs', () => {
       const element = 'lite-element';
-      const attrs = {
+      const defaultAttrs = {
         id: '123',
         src: {
           url: 'https://example.com/',
           params: ['unit', 'type'],
         },
       };
-      const args = {
+      const urlQueryParamInputs = {
         unit: 'imperial',
         type: 'main',
       };
 
-      const htmlElement = createHtml(element, attrs, args);
+      const htmlElement = createHtml(
+        element,
+        defaultAttrs,
+        {},
+        urlQueryParamInputs,
+      );
       expect(htmlElement).toEqual(
         '<lite-element id="123" src="https://example.com/?unit=imperial&type=main"></lite-element>',
       );
@@ -58,21 +64,113 @@ describe('Utils', () => {
 
     it('should construct a HTML element overwriting default attribute values with user-defined inputs', () => {
       const element = 'lite-element';
-      const attrs = {
+      const defaultAttrs = {
         id: '123',
         src: {
           url: 'https://example.com/',
           params: ['unit', 'type'],
         },
       };
-      const args = {
+      const htmlAttrInputs = {
         src: 'https://example.com/overwrite',
       };
 
-      const htmlElement = createHtml(element, attrs, args);
+      const htmlElement = createHtml(element, defaultAttrs, htmlAttrInputs);
       expect(htmlElement).toEqual(
         '<lite-element id="123" src="https://example.com/overwrite"></lite-element>',
       );
+    });
+  });
+
+  describe('formatData', () => {
+    it('should correctly format and overwrite data and inputs', () => {
+      const data = {
+        id: 'third-party',
+        description: 'Description',
+        html: {
+          element: 'iframe',
+          attributes: {
+            loading: 'lazy',
+            src: {
+              url: 'https://www.example.com/',
+              params: ['id'],
+            },
+            width: '100',
+            height: '100',
+          },
+        },
+      };
+
+      const inputs = {
+        id: '123',
+        loading: 'auto',
+        width: '150',
+      };
+
+      const result = formatData(data, inputs);
+      expect(result.html).toEqual(
+        '<iframe loading="auto" src="https://www.example.com/?id=123" width="150" height="100"></iframe>',
+      );
+      expect(result.scripts).toEqual(null);
+    });
+
+    it('should pass scripts and correctly assign params if available', () => {
+      const data = {
+        id: 'third-party',
+        description: 'Description',
+        html: {
+          element: 'iframe',
+          attributes: {
+            loading: 'lazy',
+          },
+        },
+        scripts: [
+          {
+            url: 'https://www.example.com',
+            params: ['id'],
+            strategy: 'worker',
+            location: 'head',
+            action: 'append',
+          },
+        ],
+      };
+
+      const inputs = {
+        id: '123',
+      };
+
+      const result = formatData(data as Data, inputs);
+      expect(result.html).toEqual('<iframe loading="lazy"></iframe>');
+      expect(result.scripts).not.toEqual(null);
+      expect(result.scripts!.length).toEqual(1);
+      expect(result.scripts![0].url).toEqual('https://www.example.com/?id=123');
+    });
+
+    it('should forward all additional inputs as html attributes if not used elsewhere', () => {
+      const data = {
+        id: 'third-party',
+        description: 'Description',
+        html: {
+          element: 'iframe',
+          attributes: {
+            loading: 'lazy',
+            width: '100',
+            height: '100',
+          },
+        },
+      };
+
+      const inputs = {
+        id: '123',
+        loading: 'auto',
+        width: '150',
+      };
+
+      const result = formatData(data, inputs);
+      expect(result.html).toEqual(
+        '<iframe loading="auto" width="150" height="100" id="123"></iframe>',
+      );
+      expect(result.scripts).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
This PR does the following:

- Fixes #23. This PR updates how inputs are handled to always forward additional arguments/properties provided by the user if they don't exist somewhere in the schema (as a URL param or already specified default attribute).

    For example: A React consumer that specifies `<GoogleMapsEmbed ... randomAttr="123"/>` will result in `<iframe ... randomAttr="123">`
    
- Fixes #25. Introduces a `slugParam` property to the schema that when defined by the user, either appends or replaces the slug in the `src` attribute URL

    For example, currently the `src` URL for the Google Maps Embed export is `https://www.google.com/maps/embed/v1/place`, but a new `slugParam` with a value of `mode` was added. 

    --> If a React consumer specifies `<GoogleMapsEmbed ... mode="view" />`, the output becomes `<iframe ... src="[123](https://www.google.com/maps/embed/v1/view">`