### PR TITLE
fixes GoogleAnalyticsApi and better GoogleTagManagerApi typing

### DIFF
--- a/src/types/type-declarations.ts
+++ b/src/types/type-declarations.ts
@@ -49,26 +49,55 @@ export interface Inputs {
   [key: string]: any;
 }
 
+/* Google Analytics */
 export interface GoogleAnalyticsOptions {
   id: string;
 }
 
-export interface GoogleAnalyticsApi {
-  gtag:
-    | ((fn: 'js', opt: Date) => void)
-    | ((fn: 'config', opt: string) => void)
-    | ((fn: 'event', opt: string, opt2: { [key: string]: string }) => void)
-    | ((fn: 'set', opt: { [key: string]: string }) => void)
-    | ((fn: 'get', opt: string) => void)
-    | ((fn: 'consent', opt: 'default', opt2: { [key: string]: string }) => void)
-    | ((fn: 'consent', opt: 'update', opt2: { [key: string]: string }) => void)
-    | ((fn: 'consent', opt: 'reset') => void);
+export interface GTag {
+  (fn: 'js', opt: Date): void;
+  (fn: 'config', opt: string): void;
+  (fn: 'event', opt: string, opt2: { [key: string]: any }): void;
+  (fn: 'set', opt: { [key: string]: string }): void;
+  (fn: 'get', opt: string): void;
+  (fn: 'consent', opt: 'default', opt2: { [key: string]: string }): void;
+  (fn: 'consent', opt: 'update', opt2: { [key: string]: string }): void;
+  (fn: 'config', opt: 'reset'): void;
 }
 
+export interface GoogleAnalyticsApi {
+  dataLayer: Record<string, any>[];
+  gtag: GTag;
+}
+
+/* Google Tag Manager */
 export interface GoogleTagManagerOptions {
   id: string;
 }
 
+interface GTMDataLayerApi {
+  name: 'dataLayer';
+  set: (opt: { [key: string]: string }) => void;
+  get: (key: string) => void;
+  reset: () => void;
+}
+
+type GTMDataLayerStatus = {
+  dataLayer: {
+    gtmDom: boolean;
+    gtmLoad: boolean;
+    subscribers: number;
+  };
+};
+
+export type GTM = GTMDataLayerStatus & {
+  [key: string]: {
+    callback: () => void;
+    dataLayer: GTMDataLayerApi;
+  };
+};
+
 export interface GoogleTagManagerApi {
   dataLayer: Record<string, any>[];
+  google_tag_manager: GTM;
 }


### PR DESCRIPTION
Some 🐛 fixes!

how it can be used in nuxt:

gtag
<img width="968" alt="Screenshot 2023-10-18 at 4 17 33 PM" src="https://github.com/GoogleChromeLabs/third-party-capital/assets/372973/8d0380ab-33db-4b6f-af4a-4d195699f1bf">

gtm
<img width="1049" alt="Screenshot 2023-10-18 at 4 18 04 PM" src="https://github.com/GoogleChromeLabs/third-party-capital/assets/372973/ebd2866b-7443-47d4-a974-57f6b8d554bc">

@kara 