### PR TITLE
add Output type

### DIFF
--- a/src/types/type-declarations.ts
+++ b/src/types/type-declarations.ts
@@ -50,6 +50,15 @@ export interface Inputs {
   [key: string]: any;
 }
 
+export interface Output {
+  id: string;
+  description: string;
+  website?: string;
+  html?: string;
+  stylesheets?: Array<string>;
+  scripts?: Scripts;
+}
+
 /* Google Analytics */
 export interface GoogleAnalyticsOptions {
   id: string;

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -111,7 +111,7 @@ describe('Utils', () => {
       expect(result.html).toEqual(
         '<iframe loading="auto" src="https://www.example.com/?id=props.id" width="150" height="100"></iframe>',
       );
-      expect(result.scripts).toEqual(null);
+      expect(result.scripts).toEqual(undefined);
     });
 
     it('should pass scripts and correctly assign params if available', () => {
@@ -141,7 +141,7 @@ describe('Utils', () => {
 
       const result = formatData(data as Data, inputs);
       expect(result.html).toEqual('<iframe loading="lazy"></iframe>');
-      expect(result.scripts).not.toEqual(null);
+      expect(result.scripts).not.toEqual(undefined);
       expect(result.scripts!.length).toEqual(1);
       expect((result.scripts![0] as ExternalScript).url).toEqual(
         'https://www.example.com/?id=userDefinedId',
@@ -172,7 +172,7 @@ describe('Utils', () => {
       expect(result.html).toEqual(
         '<iframe loading="auto" width="150" height="100" id="props.id"></iframe>',
       );
-      expect(result.scripts).toEqual(null);
+      expect(result.scripts).toEqual(undefined);
     });
 
     it('should include the user inputted slug to the src URL if provided as a parameter', () => {
@@ -199,7 +199,7 @@ describe('Utils', () => {
       expect(result.html).toEqual(
         '<iframe loading="lazy" src="https://www.example.com/cool-slug"></iframe>',
       );
-      expect(result.scripts).toEqual(null);
+      expect(result.scripts).toEqual(undefined);
     });
 
     it('should replace the already existing slug if the user includes a slug parameter slug', () => {
@@ -228,7 +228,7 @@ describe('Utils', () => {
       expect(result.html).toEqual(
         '<iframe loading="lazy" src="https://www.google.com/maps/embed/v1/view?key=123"></iframe>',
       );
-      expect(result.scripts).toEqual(null);
+      expect(result.scripts).toEqual(undefined);
     });
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,10 @@
-import type { Data, Inputs, AttributeVal, HtmlAttributes } from '../types';
+import type {
+  Data,
+  Inputs,
+  AttributeVal,
+  HtmlAttributes,
+  Output,
+} from '../types';
 import { isExternalScript } from '../types';
 
 function filterArgs(
@@ -85,7 +91,7 @@ export function createHtml(
 }
 
 // Format JSON by including all default and user-required parameters
-export function formatData(data: Data, args: Inputs) {
+export function formatData(data: Data, args: Inputs): Output {
   const allScriptParams = data.scripts?.reduce(
     (acc, script) => [
       ...acc,
@@ -130,7 +136,7 @@ export function formatData(data: Data, args: Inputs) {
           htmlUrlParamInputs,
           htmlSlugParamInput,
         )
-      : null,
+      : undefined,
     // Pass any required query params with user values for relevant scripts
     scripts: data.scripts
       ? data.scripts.map((script) => {
@@ -144,6 +150,6 @@ export function formatData(data: Data, args: Inputs) {
                 code: formatCode(script.code, scriptUrlParamInputs),
               };
         })
-      : null,
+      : undefined,
   };
 }


### PR DESCRIPTION
Small pr to add an `Output` type that we are returning. 
It's almost the same as the `Data` type, with the exception that the `html` value is a simple string, generated from the `formatData` function. 

@kara @housseindjirdeh 