### PR TITLE
Add support for Google Tag Manager

### DIFF
--- a/src/third-parties/google-tag-manager/data.json
+++ b/src/third-parties/google-tag-manager/data.json
@@ -1,0 +1,22 @@
+{
+    "id": "google-tag-manager",
+    "description": "Install Google Tag Manager on your website",
+    "website": "https://developers.google.com/tag-platform/tag-manager/web",
+    "scripts": [
+      {
+        "url": "https://www.googletagmanager.com/gtm.js",
+        "params": ["id"],
+        "strategy": "worker",
+        "location": "head",
+        "action": "append",
+        "key": "gtm"
+      },
+      {
+        "code": "window.dataLayer=window.dataLayer||[];window.dataLayer.push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
+        "strategy": "worker",
+        "location": "head",
+        "action": "append",
+        "key": "setup"
+      }
+    ]
+}

--- a/src/third-parties/google-tag-manager/index.ts
+++ b/src/third-parties/google-tag-manager/index.ts
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export { GoogleAnalytics } from './third-parties/google-analytics';
-export { GoogleTagManager } from './third-parties/google-tag-manager';
-export { GoogleMapsEmbed } from './third-parties/google-maps-embed';
-export { YouTubeEmbed } from './third-parties/youtube-embed';
+import data from './data.json';
+import { formatData } from '../../utils';
+import type { Data, Inputs } from '../../types';
 
-export * from './types';
+export const GoogleTagManager = ({ ...args }: Inputs) => {
+  return formatData(data as Data, args);
+};


### PR DESCRIPTION
This pr assumes that we don't need to support the <noscript> option of the default install code.

for reference - default install code from head section:
```
<!-- Google Tag Manager -->
<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
})(window,document,'script','dataLayer','INSERT_ID);</script>
<!-- End Google Tag Manager -->
```

default install code from body section:
```
<!-- Google Tag Manager (noscript) -->
<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=INSERT_ID"
height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
<!-- End Google Tag Manager (noscript) -->
```

feel free to tweak - this was just the initial setup - assuming we want it to be fairly close to the Google Analytics setup. 
@kara 