### PR TITLE
fix(gtag): access to `gtag()` through `window`

### DIFF
--- a/src/third-parties/google-analytics/data.json
+++ b/src/third-parties/google-analytics/data.json
@@ -12,7 +12,7 @@
       "key": "gtag"
     },
     {
-      "code": "window.dataLayer=window.dataLayer||[];window.gtag=function gtag(){window.dataLayer.push(arguments);};gtag('js',new Date());gtag('config','{{id}}')",
+      "code": "window.dataLayer=window.dataLayer||[];window.gtag=function gtag(){window.dataLayer.push(arguments);};window.gtag('js',new Date());window.gtag('config','{{id}}')",
       "strategy": "worker",
       "location": "head",
       "action": "append",


### PR DESCRIPTION
Hi :wave: 

This PR make function calls trhough `window` instead of using global. It is probably better to access it though the `window` object. Also because this breaks https://github.com/nuxt/scripts/actions/runs/9408083008/job/25915269497?pr=81