### PR TITLE
fix: assign dataLayer from gtag to the datalayers object

### DIFF
--- a/src/third-parties/google-analytics/data.json
+++ b/src/third-parties/google-analytics/data.json
@@ -5,14 +5,14 @@
   "scripts": [
     {
       "url": "https://www.googletagmanager.com/gtag/js",
-      "params": ["id"],
+      "params": ["id", "l"],
       "strategy": "worker",
       "location": "head",
       "action": "append",
       "key": "gtag"
     },
     {
-      "code": "window.dataLayers=window.dataLayers||{};window.dataLayers['{{dataLayerName}}']=window.dataLayers['{{dataLayerName}}']||[];window.gtag=function gtag(){window.dataLayers['{{dataLayerName}}'].push(arguments);};window.gtag('js',new Date());window.gtag('config','{{id}}')",
+      "code": "window.dataLayers=window.dataLayers||{};window.dataLayers['{{dataLayerName}}']=window.dataLayers['{{dataLayerName}}']||window.{{dataLayerName}}||[];window.gtag=function gtag(){window.dataLayers['{{dataLayerName}}'].push(arguments);};window.gtag('js',new Date());window.gtag('config','{{id}}')",
       "params": ["id", "dataLayerName"],
       "strategy": "worker",
       "location": "head",

--- a/src/third-parties/google-analytics/data.json
+++ b/src/third-parties/google-analytics/data.json
@@ -12,7 +12,7 @@
       "key": "gtag"
     },
     {
-      "code": "window.dataLayers=window.dataLayers||{};window.dataLayers['{{dataLayerName}}']=window.dataLayers['{{dataLayerName}}']||window.{{dataLayerName}}||[];window.gtag=function gtag(){window.dataLayers['{{dataLayerName}}'].push(arguments);};window.gtag('js',new Date());window.gtag('config','{{id}}')",
+      "code": "window.dataLayers=window.dataLayers||{};window.dataLayers['{{dataLayerName}}']=window.dataLayers['{{dataLayerName}}']||window['{{dataLayerName}}']||[];window.gtag=function gtag(){window.dataLayers['{{dataLayerName}}'].push(arguments);};window.gtag('js',new Date());window.gtag('config','{{id}}')",
       "params": ["id", "dataLayerName"],
       "strategy": "worker",
       "location": "head",

--- a/src/third-parties/google-tag-manager/data.json
+++ b/src/third-parties/google-tag-manager/data.json
@@ -5,14 +5,14 @@
     "scripts": [
       {
         "url": "https://www.googletagmanager.com/gtm.js",
-        "params": ["id"],
+        "params": ["id", "l"],
         "strategy": "worker",
         "location": "head",
         "action": "append",
         "key": "gtm"
       },
       {
-        "code": "window.dataLayers=window.dataLayers||{};window.dataLayers['{{dataLayerName}}']=window.dataLayers['{{dataLayerName}}']||[];window.dataLayers['{{dataLayerName}}'].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
+        "code": "window.dataLayers=window.dataLayers||{};window.dataLayers['{{dataLayerName}}']=window.dataLayers['{{dataLayerName}}']||window.{{dataLayerName}}||[];window.dataLayers['{{dataLayerName}}'].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
         "params": ["dataLayerName"],
         "strategy": "worker",
         "location": "head",

--- a/src/third-parties/google-tag-manager/data.json
+++ b/src/third-parties/google-tag-manager/data.json
@@ -12,7 +12,7 @@
         "key": "gtm"
       },
       {
-        "code": "window.dataLayers=window.dataLayers||{};window.dataLayers['{{dataLayerName}}']=window.dataLayers['{{dataLayerName}}']||window.{{dataLayerName}}||[];window.dataLayers['{{dataLayerName}}'].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
+        "code": "window.dataLayers=window.dataLayers||{};window.dataLayers['{{dataLayerName}}']=window.dataLayers['{{dataLayerName}}']||window['{{dataLayerName}}']||[];window.dataLayers['{{dataLayerName}}'].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
         "params": ["dataLayerName"],
         "strategy": "worker",
         "location": "head",

--- a/src/types/type-declarations.ts
+++ b/src/types/type-declarations.ts
@@ -62,6 +62,10 @@ export interface Output {
 /* Google Analytics */
 export interface GoogleAnalyticsParams {
   id: string;
+  /**
+   * The name of the dataLayer object. Defaults to 'dataLayer'.
+   */
+  l?: string;
 }
 
 export interface GTag {
@@ -83,6 +87,10 @@ export interface GoogleAnalyticsApi {
 /* Google Tag Manager */
 export interface GoogleTagManagerParams {
   id: string;
+  /**
+   * The name of the dataLayer object. Defaults to 'dataLayer'.
+   */
+  l?: string;
 }
 
 interface GoogleTagManagerDataLayerApi {


### PR DESCRIPTION
Hey :wave: 

This PR fix #55 . The issue is that we were creating our own dataLayers object to store the arrays from gtm. One thing was missing which is the `l` query parameter in the external script : https://developers.google.com/tag-platform/tag-manager/datalayer