### PR TITLE
fix: change type to avoid name conflict

### DIFF
--- a/src/types/type-declarations.ts
+++ b/src/types/type-declarations.ts
@@ -100,7 +100,7 @@ type GoogleTagManagerDataLayerStatus = {
   };
 };
 
-export type GoogleTagManager = GoogleTagManagerDataLayerStatus & {
+export type GoogleTagManagerInstance = GoogleTagManagerDataLayerStatus & {
   [key: string]: {
     callback: () => void;
     dataLayer: GoogleTagManagerDataLayerApi;
@@ -109,7 +109,7 @@ export type GoogleTagManager = GoogleTagManagerDataLayerStatus & {
 
 export interface GoogleTagManagerApi {
   dataLayers: Record<string, Record<string, any>[]>;
-  google_tag_manager: GoogleTagManager;
+  google_tag_manager: GoogleTagManagerInstance;
 }
 
 /* Google Maps Embed */


### PR DESCRIPTION
Hey :wave:

this PR fix the ci of https://github.com/nuxt/scripts/pull/176 . This is caused by a type GoogleTagManager and a var GoogleTagManager so it conflicts at build time. This PR renmae the type to GoogleTagManagerIsntance