### PR TITLE
fix: add optionalPrams properties in JSON data

### DIFF
--- a/src/third-parties/google-analytics/data.json
+++ b/src/third-parties/google-analytics/data.json
@@ -6,7 +6,7 @@
     {
       "url": "https://www.googletagmanager.com/gtag/js",
       "params": ["id"],
-      "optionalParams": ["l"],
+      "optionalParam": ["l"],
       "strategy": "worker",
       "location": "head",
       "action": "append",
@@ -15,7 +15,7 @@
     {
       "code": "window['{{l}}'??'dataLayer']=window['{{l}}'??'dataLayer']||[];window['{{l}}'??'dataLayer'].push({'js':new Date()});window['{{l}}'??'dataLayer'].push({'config':'{{id}}'})",
       "params": ["id"],
-      "optionalParams": ["l"],
+      "optionalParam": ["l"],
       "strategy": "worker",
       "location": "head",
       "action": "append",

--- a/src/third-parties/google-analytics/data.json
+++ b/src/third-parties/google-analytics/data.json
@@ -5,17 +5,21 @@
   "scripts": [
     {
       "url": "https://www.googletagmanager.com/gtag/js",
-      "params": ["id", "l"],
-      "optionalParam": ["l"],
+      "params": ["id"],
+      "optionalParams": {
+        "l": null
+      },
       "strategy": "worker",
       "location": "head",
       "action": "append",
       "key": "gtag"
     },
     {
-      "code": "window[{{l}}??'dataLayer']=window[{{l}}??'dataLayer']||[];window[{{l}}??'dataLayer'].push({'js':new Date()});window[{{l}}??'dataLayer'].push({'config':{{id}}})",
+      "code": "window[{{l}}]=window[{{l}}]||[];window[{{l}}].push({'js':new Date()});window[{{l}}].push({'config':{{id}}})",
       "params": ["id"],
-      "optionalParam": ["l"],
+      "optionalParams": {
+        "l": "dataLayer"
+      },
       "strategy": "worker",
       "location": "head",
       "action": "append",

--- a/src/third-parties/google-analytics/data.json
+++ b/src/third-parties/google-analytics/data.json
@@ -5,7 +5,7 @@
   "scripts": [
     {
       "url": "https://www.googletagmanager.com/gtag/js",
-      "params": ["id"],
+      "params": ["id", "l"],
       "optionalParam": ["l"],
       "strategy": "worker",
       "location": "head",

--- a/src/third-parties/google-analytics/data.json
+++ b/src/third-parties/google-analytics/data.json
@@ -13,7 +13,7 @@
       "key": "gtag"
     },
     {
-      "code": "window['{{l}}'??'dataLayer']=window['{{l}}'??'dataLayer']||[];window['{{l}}'??'dataLayer'].push({'js':new Date()});window['{{l}}'??'dataLayer'].push({'config':'{{id}}'})",
+      "code": "window[{{l}}??'dataLayer']=window[{{l}}??'dataLayer']||[];window[{{l}}??'dataLayer'].push({'js':new Date()});window[{{l}}??'dataLayer'].push({'config':{{id}}})",
       "params": ["id"],
       "optionalParam": ["l"],
       "strategy": "worker",

--- a/src/third-parties/google-analytics/data.json
+++ b/src/third-parties/google-analytics/data.json
@@ -5,15 +5,17 @@
   "scripts": [
     {
       "url": "https://www.googletagmanager.com/gtag/js",
-      "params": ["id", "l"],
+      "params": ["id"],
+      "optionalParams": ["l"],
       "strategy": "worker",
       "location": "head",
       "action": "append",
       "key": "gtag"
     },
     {
-      "code": "window['{{l}}']=window['{{l}}']||[];window['{{l}}'].push({'js':new Date()});window['{{l}}'].push({'config':'{{id}}'})",
-      "params": ["id", "l"],
+      "code": "window['{{l}}'??'dataLayer']=window['{{l}}'??'dataLayer']||[];window['{{l}}'??'dataLayer'].push({'js':new Date()});window['{{l}}'??'dataLayer'].push({'config':'{{id}}'})",
+      "params": ["id"],
+      "optionalParams": ["l"],
       "strategy": "worker",
       "location": "head",
       "action": "append",

--- a/src/third-parties/google-tag-manager/data.json
+++ b/src/third-parties/google-tag-manager/data.json
@@ -5,7 +5,7 @@
     "scripts": [
       {
         "url": "https://www.googletagmanager.com/gtm.js",
-        "params": ["id"],
+        "params": ["id", "l"],
         "optionalParam": ["l"],
         "strategy": "worker",
         "location": "head",

--- a/src/third-parties/google-tag-manager/data.json
+++ b/src/third-parties/google-tag-manager/data.json
@@ -5,16 +5,20 @@
     "scripts": [
       {
         "url": "https://www.googletagmanager.com/gtm.js",
-        "params": ["id", "l"],
-        "optionalParam": ["l"],
+        "params": ["id"],
+        "optionalParams": {
+          "l": null
+        },
         "strategy": "worker",
         "location": "head",
         "action": "append",
         "key": "gtm"
       },
       {
-        "code": "window[{{l}}??'dataLayer']=window[{{l}}??'dataLayer']||[];window[{{l}}??'dataLayer'].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
-        "optionalParam": ["l"],
+        "code": "window[{{l}}]=window[{{l}}]||[];window[{{l}}].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
+        "optionalParams": {
+          "l": "dataLayer"
+        },
         "strategy": "worker",
         "location": "head",
         "action": "append",

--- a/src/third-parties/google-tag-manager/data.json
+++ b/src/third-parties/google-tag-manager/data.json
@@ -13,7 +13,7 @@
         "key": "gtm"
       },
       {
-        "code": "window['{{l}}'??'dataLayer']=window['{{l}}'??'dataLayer']||[];window['{{l}}'??'dataLayer'].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
+        "code": "window[{{l}}??'dataLayer']=window[{{l}}??'dataLayer']||[];window[{{l}}??'dataLayer'].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
         "optionalParam": ["l"],
         "strategy": "worker",
         "location": "head",

--- a/src/third-parties/google-tag-manager/data.json
+++ b/src/third-parties/google-tag-manager/data.json
@@ -5,15 +5,16 @@
     "scripts": [
       {
         "url": "https://www.googletagmanager.com/gtm.js",
-        "params": ["id", "l"],
+        "params": ["id"],
+        "optionalParams": ["l"],
         "strategy": "worker",
         "location": "head",
         "action": "append",
         "key": "gtm"
       },
       {
-        "code": "window['{{l}}']=window['{{l}}']||[];window['{{l}}'].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
-        "params": ["l"],
+        "code": "window['{{l}}'??'dataLayer']=window['{{l}}'??'dataLayer']||[];window['{{l}}'??'dataLayer'].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
+        "optionalParams": ["l"],
         "strategy": "worker",
         "location": "head",
         "action": "append",

--- a/src/third-parties/google-tag-manager/data.json
+++ b/src/third-parties/google-tag-manager/data.json
@@ -6,7 +6,7 @@
       {
         "url": "https://www.googletagmanager.com/gtm.js",
         "params": ["id"],
-        "optionalParams": ["l"],
+        "optionalParam": ["l"],
         "strategy": "worker",
         "location": "head",
         "action": "append",
@@ -14,7 +14,7 @@
       },
       {
         "code": "window['{{l}}'??'dataLayer']=window['{{l}}'??'dataLayer']||[];window['{{l}}'??'dataLayer'].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
-        "optionalParams": ["l"],
+        "optionalParam": ["l"],
         "strategy": "worker",
         "location": "head",
         "action": "append",

--- a/src/types/type-declarations.ts
+++ b/src/types/type-declarations.ts
@@ -17,7 +17,7 @@ export type HtmlAttributes = {
 
 type ScriptBase = {
   params?: Array<string>;
-  optionalParams?: Record<string, string | number | undefined>;
+  optionalParams?: Record<string, string | number | undefined | null>;
   strategy: ScriptStrategy;
   location: ScriptLocation;
   action: ScriptAction;

--- a/src/types/type-declarations.ts
+++ b/src/types/type-declarations.ts
@@ -17,7 +17,7 @@ export type HtmlAttributes = {
 
 type ScriptBase = {
   params?: Array<string>;
-  optionalParam?: Array<string>;
+  optionalParams?: Record<string, string | number | undefined>;
   strategy: ScriptStrategy;
   location: ScriptLocation;
   action: ScriptAction;

--- a/src/types/type-declarations.ts
+++ b/src/types/type-declarations.ts
@@ -17,6 +17,7 @@ export type HtmlAttributes = {
 
 type ScriptBase = {
   params?: Array<string>;
+  optionalParam?: Array<string>;
   strategy: ScriptStrategy;
   location: ScriptLocation;
   action: ScriptAction;

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,4 +1,4 @@
-import { formatUrl, createHtml, formatData } from '.';
+import { formatUrl, createHtml, formatData, formatCode } from '.';
 import type { Data, ExternalScript } from '../types';
 
 describe('Utils', () => {
@@ -230,5 +230,51 @@ describe('Utils', () => {
       );
       expect(result.scripts).toEqual(undefined);
     });
+  });
+  describe('formatCode', () => {
+    it.each([
+      // string
+      {
+        input: "window[{{l}}??'dataLayer']=window[{{l}}??'dataLayer']||[];",
+        params: {
+          l: 'some-datalayer',
+        },
+        output: `window["some-datalayer"??'dataLayer']=window["some-datalayer"??'dataLayer']||[];`,
+      },
+      // number
+      {
+        input: '{{number}}+1',
+        params: {
+          number: 4,
+        },
+        output: `4+1`,
+      },
+      // boolean
+      {
+        input: '{{bool}}',
+        params: {
+          bool: false,
+        },
+        output: `false`,
+      },
+      // null
+      {
+        input: '{{val}}',
+        params: {
+          val: null,
+        },
+        output: `null`,
+      },
+      // undefined
+      {
+        input: "window[{{l}}??'dataLayer']=window[{{l}}??'dataLayer']||[];",
+        output: `window[undefined??'dataLayer']=window[undefined??'dataLayer']||[];`,
+      },
+    ])(
+      'should replace the input and stringify it',
+      ({ input, output, params }) => {
+        expect(formatCode(input, params)).toEqual(output);
+      },
+    );
   });
 });

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,5 +1,5 @@
 import { formatUrl, createHtml, formatData, formatCode } from '.';
-import type { Data, ExternalScript } from '../types';
+import type { CodeBlock, Data, ExternalScript } from '../types';
 
 describe('Utils', () => {
   describe('formatUrl', () => {
@@ -249,6 +249,50 @@ describe('Utils', () => {
         '<iframe loading="lazy" src="https://www.google.com/maps/embed/v1/view?key=123"></iframe>',
       );
       expect(result.scripts).toEqual(undefined);
+    });
+
+    it('should replace with default values when needed', () => {
+      const data = {
+        id: 'third-party',
+        description: 'Description',
+        html: {
+          element: 'iframe',
+          attributes: {
+            loading: 'lazy',
+            src: {
+              url: 'https://www.google.com/maps/embed/v1/place',
+              slugParam: 'mode',
+              params: ['key'],
+            },
+          },
+        },
+        scripts: [
+          {
+            code: 'window[{{hello}}]=window[{{hello}}]||[];console.log({{world}})',
+            optionalParams: {
+              hello: 'hoho',
+            },
+            params: ['world'],
+            strategy: 'worker',
+            location: 'head',
+            action: 'append',
+            key: 'setup',
+          } as CodeBlock,
+        ],
+      };
+
+      const result = formatData(data, {
+        test: 'hello',
+        world: 'earth',
+        key: 404,
+      });
+      const script = result.scripts![0] as CodeBlock;
+      expect(script.code).toEqual(
+        'window["hoho"]=window["hoho"]||[];console.log("earth")',
+      );
+      expect(result.html).toEqual(
+        '<iframe loading="lazy" src="https://www.google.com/maps/embed/v1/place?key=404" test="hello"></iframe>',
+      );
     });
   });
 

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -322,6 +322,14 @@ describe('Utils', () => {
         },
         output: `false`,
       },
+      // boolean
+      {
+        input: '{{val}}',
+        params: {
+          val: null,
+        },
+        output: `null`,
+      },
       // undefined
       {
         input: 'window[{{l}}]=window[{{l}}]||[];',

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -14,6 +14,26 @@ describe('Utils', () => {
       const newUrl = formatUrl(oldUrl, requiredParams, args);
       expect(newUrl).toEqual('https://example.com/?unit=imperial&type=main');
     });
+
+    it('should add default value', () => {
+      const oldUrl = 'https://example.com';
+      const requiredParams = ['unit', 'type'];
+      const args = {
+        unit: 'imperial',
+      };
+      const optionalParams = {
+        type: 'main',
+      };
+
+      const newUrl = formatUrl(
+        oldUrl,
+        requiredParams,
+        args,
+        undefined,
+        optionalParams,
+      );
+      expect(newUrl).toEqual('https://example.com/?unit=imperial&type=main');
+    });
   });
 
   describe('createHtml', () => {
@@ -231,15 +251,16 @@ describe('Utils', () => {
       expect(result.scripts).toEqual(undefined);
     });
   });
+
   describe('formatCode', () => {
-    it.each([
+    const inputs = [
       // string
       {
-        input: "window[{{l}}??'dataLayer']=window[{{l}}??'dataLayer']||[];",
+        input: 'window[{{l}}]=window[{{l}}]||[];',
         params: {
           l: 'some-datalayer',
         },
-        output: `window["some-datalayer"??'dataLayer']=window["some-datalayer"??'dataLayer']||[];`,
+        output: `window["some-datalayer"]=window["some-datalayer"]||[];`,
       },
       // number
       {
@@ -257,24 +278,33 @@ describe('Utils', () => {
         },
         output: `false`,
       },
-      // null
-      {
-        input: '{{val}}',
-        params: {
-          val: null,
-        },
-        output: `null`,
-      },
       // undefined
       {
-        input: "window[{{l}}??'dataLayer']=window[{{l}}??'dataLayer']||[];",
-        output: `window[undefined??'dataLayer']=window[undefined??'dataLayer']||[];`,
+        input: 'window[{{l}}]=window[{{l}}]||[];',
+        output: `window[undefined]=window[undefined]||[];`,
       },
-    ])(
+    ];
+
+    it.each(inputs)(
       'should replace the input and stringify it',
       ({ input, output, params }) => {
         expect(formatCode(input, params)).toEqual(output);
       },
     );
+
+    it.each(inputs)(
+      'should replace the input and stringify it with the default value',
+      ({ input, output, params }) => {
+        expect(formatCode(input, undefined, params)).toEqual(output);
+      },
+    );
+
+    it('should replace the input and stringify it with the default value', () => {
+      const input = 'window[{{l}}]=window[{{l}}]||[];';
+
+      expect(
+        formatCode(input, { l: 'test' }, { l: 'dataLayer' }),
+      ).toMatchInlineSnapshot(`"window["test"]=window["test"]||[];"`);
+    });
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -30,6 +30,7 @@ export function formatUrl(
   params?: string[],
   args?: Inputs,
   slug?: Inputs,
+  optionalParams?: Inputs,
 ) {
   const newUrl =
     slug && Object.keys(slug).length > 0
@@ -39,15 +40,23 @@ export function formatUrl(
   if (params && args) {
     params.forEach((param: string) => {
       if (args[param]) newUrl.searchParams.set(param, args[param]);
+      else if (optionalParams?.[param]) {
+        newUrl.searchParams.set(param, optionalParams?.[param]);
+      }
     });
   }
 
   return newUrl.toString();
 }
 
-export function formatCode(code: string, args?: Inputs) {
+export function formatCode(
+  code: string,
+  args?: Inputs,
+  optionalParams?: Inputs,
+) {
   return code.replace(/{{(.*?)}}/g, (match) => {
-    return JSON.stringify(args?.[match.split(/{{|}}/).filter(Boolean)[0]]);
+    const name = match.split(/{{|}}/).filter(Boolean)[0];
+    return JSON.stringify(args?.[name] ?? optionalParams?.[name]);
   });
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -56,7 +56,9 @@ export function formatCode(
 ) {
   return code.replace(/{{(.*?)}}/g, (match) => {
     const name = match.split(/{{|}}/).filter(Boolean)[0];
-    return JSON.stringify(args?.[name] ?? optionalParams?.[name]);
+    return JSON.stringify(
+      args && name in args ? args?.[name] : optionalParams?.[name],
+    );
   });
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -47,7 +47,7 @@ export function formatUrl(
 
 export function formatCode(code: string, args?: Inputs) {
   return code.replace(/{{(.*?)}}/g, (match) => {
-    return args?.[match.split(/{{|}}/).filter(Boolean)[0]];
+    return JSON.stringify(args?.[match.split(/{{|}}/).filter(Boolean)[0]]);
   });
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -105,6 +105,7 @@ export function formatData(data: Data, args: Inputs): Output {
     (acc, script) => [
       ...acc,
       ...(Array.isArray(script.params) ? script.params : []),
+      ...(script.optionalParams ? Object.keys(script.optionalParams) : []),
     ],
     [] as string[],
   );
@@ -152,11 +153,21 @@ export function formatData(data: Data, args: Inputs): Output {
           return isExternalScript(script)
             ? {
                 ...script,
-                url: formatUrl(script.url, script.params, scriptUrlParamInputs),
+                url: formatUrl(
+                  script.url,
+                  allScriptParams,
+                  scriptUrlParamInputs,
+                  undefined,
+                  script.optionalParams,
+                ),
               }
             : {
                 ...script,
-                code: formatCode(script.code, scriptUrlParamInputs),
+                code: formatCode(
+                  script.code,
+                  scriptUrlParamInputs,
+                  script.optionalParams,
+                ),
               };
         })
       : undefined,


### PR DESCRIPTION
fix #58

Hey :wave: this PR move optional params into an `optionalParam` array. It also adds default values to `code`.

This should allow integrations to avoid adding default values that can be handled by tpc or google scripts. 