### PR TITLE
fix: use Parameters<Gtag> for datalayer

### DIFF
--- a/src/types/type-declarations.ts
+++ b/src/types/type-declarations.ts
@@ -80,7 +80,7 @@ export interface GTag {
   (fn: 'config', opt: 'reset'): void;
 }
 
-export type DataLayer = Parameters<GTag>[];
+export type DataLayer = Array<Parameters<GTag> | Record<string, unknown>>;
 
 /* Google Tag Manager */
 export interface GoogleTagManagerParams {

--- a/src/types/type-declarations.ts
+++ b/src/types/type-declarations.ts
@@ -80,7 +80,7 @@ export interface GTag {
   (fn: 'config', opt: 'reset'): void;
 }
 
-export type DataLayer = Record<string, unknown>[];
+export type DataLayer = Parameters<GTag>[];
 
 /* Google Tag Manager */
 export interface GoogleTagManagerParams {


### PR DESCRIPTION
When typing a function as `GTag`, we cannot `push` the args into `DataLayer` due to its type.