### PR TITLE
fix(ga): setup default consent state

### DIFF
--- a/data/google-analytics.json
+++ b/data/google-analytics.json
@@ -15,10 +15,18 @@
       "key": "gtag"
     },
     {
-      "code": "window[{{l}}]=window[{{l}}]||[];window['gtag-'+{{l}}]=function (){window[{{l}}].push(arguments);};window['gtag-'+{{l}}]('consent', 'default', {'ad_user_data': 'denied','ad_personalization': 'denied','ad_storage': 'denied','analytics_storage': 'denied','wait_for_update': 500,});window['gtag-'+{{l}}]('js',new Date());window['gtag-'+{{l}}]('config',{{id}})",
+      "code": "window[{{l}}]=window[{{l}}]||[];window['gtag-'+{{l}}]=function (){window[{{l}}].push(arguments);};window['gtag-'+{{l}}]('consent', {{consentType}}, {{consentValues}});window['gtag-'+{{l}}]('js',new Date());window['gtag-'+{{l}}]('config',{{id}})",
       "params": ["id"],
       "optionalParams": {
-        "l": "dataLayer"
+        "l": "dataLayer",
+        "consentType": "default",
+        "consentValues": {
+          "ad_user_data": "denied",
+          "ad_personalization": "denied",
+          "ad_storage": "denied",
+          "analytics_storage": "denied",
+          "wait_for_update": 500
+        }
       },
       "strategy": "worker",
       "location": "head",

--- a/data/google-analytics.json
+++ b/data/google-analytics.json
@@ -15,7 +15,7 @@
       "key": "gtag"
     },
     {
-      "code": "window[{{l}}]=window[{{l}}]||[];window['gtag-'+{{l}}]=function (){window[{{l}}].push(arguments);};window['gtag-'+{{l}}]('js',new Date());window['gtag-'+{{l}}]('config',{{id}})",
+      "code": "window[{{l}}]=window[{{l}}]||[];window['gtag-'+{{l}}]=function (){window[{{l}}].push(arguments);};window['gtag-'+{{l}}]('consent', 'default', {'ad_user_data': 'denied','ad_personalization': 'denied','ad_storage': 'denied','analytics_storage': 'denied','wait_for_update': 500,});window['gtag-'+{{l}}]('js',new Date());window['gtag-'+{{l}}]('config',{{id}})",
       "params": ["id"],
       "optionalParams": {
         "l": "dataLayer"

--- a/src/types/type-declarations.ts
+++ b/src/types/type-declarations.ts
@@ -67,6 +67,16 @@ export interface GoogleAnalyticsParams {
    * The name of the dataLayer object. Defaults to 'dataLayer'.
    */
   l?: string;
+  /**
+   * Consent type for Google Analytics.
+   * @default 'default'
+   */
+  consentType?: string;
+  /**
+   * Consent values for Google Analytics.
+   * @default {{"ad_user_data":"denied","ad_personalization":"denied","ad_storage":"denied","analytics_storage":"denied","wait_for_update":500}}
+   */
+  consentValues?: { [key: string]: string };
 }
 
 export interface GTag {

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -322,7 +322,7 @@ describe('Utils', () => {
         },
         output: `false`,
       },
-      // boolean
+      // null
       {
         input: '{{val}}',
         params: {
@@ -334,6 +334,14 @@ describe('Utils', () => {
       {
         input: 'window[{{l}}]=window[{{l}}]||[];',
         output: `window[undefined]=window[undefined]||[];`,
+      },
+      // object
+      {
+        input: '{{obj}}',
+        params: {
+          obj: { key: 'value' },
+        },
+        output: `{"key":"value"}`,
       },
     ];
 


### PR DESCRIPTION
https://github.com/nuxt/scripts/issues/243

Hey :wave: this PR set the consent mode to false by default in GA. 

https://developers.google.com/tag-platform/security/guides/consent?consentmode=basic#gtag.js

output with nuxt-scripts when denied by default

![image](https://github.com/user-attachments/assets/bcb73fab-84df-4975-b215-7b4d6d7872af)


output with nuxt-script when we did update the consent mode

![image](https://github.com/user-attachments/assets/2bd38066-ddb4-4258-a874-0b36d252df3b)
