### PR TITLE
feat(gtm): add optionnal consent mode

### DIFF
--- a/data/google-tag-manager.json
+++ b/data/google-tag-manager.json
@@ -15,17 +15,10 @@
         "key": "gtm"
       },
       {
-        "code": "window[{{l}}]=window[{{l}}]||[];(function () {window[{{l}}].push(arguments)})('consent', {{consentType}},{{consentValues}});window[{{l}}].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
+        "code": "window[{{l}}]=window[{{l}}]||[];{{#consentValues}}(function () {window[{{l}}].push(arguments)})('consent', {{consentType}},{{consentValues}});{{/consentValues}}window[{{l}}].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
         "optionalParams": {
           "l": "dataLayer",
-          "consentType": "default",
-          "consentValues": {
-            "ad_user_data": "denied",
-            "ad_personalization": "denied",
-            "ad_storage": "denied",
-            "analytics_storage": "denied",
-            "wait_for_update": 500
-          }
+          "consentType": "default"
         },
         "strategy": "worker",
         "location": "head",

--- a/data/google-tag-manager.json
+++ b/data/google-tag-manager.json
@@ -15,7 +15,7 @@
         "key": "gtm"
       },
       {
-        "code": "window[{{l}}]=window[{{l}}]||[];(() => window[{{l}}].push(arguments))('consent', 'default', {ad_user_data: 'denied',ad_personalization: 'denied',ad_storage: 'denied',analytics_storage: 'denied',wait_for_update: 500});window[{{l}}].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
+        "code": "window[{{l}}]=window[{{l}}]||[];(function () {window[{{l}}].push(arguments)})('consent', 'default', { ad_user_data: 'denied', ad_personalization: 'denied', ad_storage: 'denied', analytics_storage: 'denied', wait_for_update: 500 });window[{{l}}].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
         "optionalParams": {
           "l": "dataLayer"
         },

--- a/data/google-tag-manager.json
+++ b/data/google-tag-manager.json
@@ -18,7 +18,8 @@
         "code": "window[{{l}}]=window[{{l}}]||[];{{#consentValues}}(function () {window[{{l}}].push(arguments)})('consent', {{consentType}},{{consentValues}});{{/consentValues}}window[{{l}}].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
         "optionalParams": {
           "l": "dataLayer",
-          "consentType": "default"
+          "consentType": "default",
+          "consentValues": null
         },
         "strategy": "worker",
         "location": "head",

--- a/data/google-tag-manager.json
+++ b/data/google-tag-manager.json
@@ -15,9 +15,17 @@
         "key": "gtm"
       },
       {
-        "code": "window[{{l}}]=window[{{l}}]||[];(function () {window[{{l}}].push(arguments)})('consent', 'default', { ad_user_data: 'denied', ad_personalization: 'denied', ad_storage: 'denied', analytics_storage: 'denied', wait_for_update: 500 });window[{{l}}].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
+        "code": "window[{{l}}]=window[{{l}}]||[];(function () {window[{{l}}].push(arguments)})('consent', {{consentType}},{{consentValues}});window[{{l}}].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
         "optionalParams": {
-          "l": "dataLayer"
+          "l": "dataLayer",
+          "consentType": "default",
+          "consentValues": {
+            "ad_user_data": "denied",
+            "ad_personalization": "denied",
+            "ad_storage": "denied",
+            "analytics_storage": "denied",
+            "wait_for_update": 500
+          }
         },
         "strategy": "worker",
         "location": "head",

--- a/data/google-tag-manager.json
+++ b/data/google-tag-manager.json
@@ -15,7 +15,7 @@
         "key": "gtm"
       },
       {
-        "code": "window[{{l}}]=window[{{l}}]||[];window[{{l}}].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
+        "code": "window[{{l}}]=window[{{l}}]||[];(() => window[{{l}}].push(arguments))('consent', 'default', {ad_user_data: 'denied',ad_personalization: 'denied',ad_storage: 'denied',analytics_storage: 'denied',wait_for_update: 500});window[{{l}}].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
         "optionalParams": {
           "l": "dataLayer"
         },

--- a/src/types/type-declarations.ts
+++ b/src/types/type-declarations.ts
@@ -106,7 +106,6 @@ export interface GoogleTagManagerParams {
   consentType?: string;
   /**
    * Consent values for Google Tag Manager.
-   * @default {{"ad_user_data":"denied","ad_personalization":"denied","ad_storage":"denied","analytics_storage":"denied","wait_for_update":500}}
    */
   consentValues?: { [key: string]: string };
 }

--- a/src/types/type-declarations.ts
+++ b/src/types/type-declarations.ts
@@ -89,6 +89,16 @@ export interface GoogleTagManagerParams {
    * The name of the dataLayer object. Defaults to 'dataLayer'.
    */
   l?: string;
+  /**
+   * Consent type for Google Tag Manager.
+   * @default 'default'
+   */
+  consentType?: string;
+  /**
+   * Consent values for Google Tag Manager.
+   * @default {{"ad_user_data":"denied","ad_personalization":"denied","ad_storage":"denied","analytics_storage":"denied","wait_for_update":500}}
+   */
+  consentValues?: { [key: string]: string };
 }
 
 interface GoogleTagManagerDataLayerApi {


### PR DESCRIPTION
linked to https://github.com/nuxt/scripts/issues/243
same as https://github.com/GoogleChromeLabs/third-party-capital/pull/71 but for GTM

Seems like this require to push `arguments` into the datalayer array. 🤷‍♂️ 

Result with the GTM debugger:

![image](https://github.com/user-attachments/assets/e139abb9-61e4-4725-9c29-45536b27e47e)
