### PR TITLE
Implement a very simple conditional templating system

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ node_modules/
 lib/
 .husky
 dist/
+vendor/

--- a/data/google-analytics.json
+++ b/data/google-analytics.json
@@ -15,18 +15,12 @@
       "key": "gtag"
     },
     {
-      "code": "window[{{l}}]=window[{{l}}]||[];window['gtag-'+{{l}}]=function (){window[{{l}}].push(arguments);};window['gtag-'+{{l}}]('consent', {{consentType}}, {{consentValues}});window['gtag-'+{{l}}]('js',new Date());window['gtag-'+{{l}}]('config',{{id}})",
+      "code": "window[{{l}}]=window[{{l}}]||[];window['gtag-'+{{l}}]=function (){window[{{l}}].push(arguments);};{{#consentValues}}window['gtag-'+{{l}}]('consent', {{consentType}}, {{consentValues}});{{/consentValues}}window['gtag-'+{{l}}]('js',new Date());window['gtag-'+{{l}}]('config',{{id}})",
       "params": ["id"],
       "optionalParams": {
         "l": "dataLayer",
         "consentType": "default",
-        "consentValues": {
-          "ad_user_data": "denied",
-          "ad_personalization": "denied",
-          "ad_storage": "denied",
-          "analytics_storage": "denied",
-          "wait_for_update": 500
-        }
+        "consentValues": null
       },
       "strategy": "worker",
       "location": "head",

--- a/inc/Data/ThirdPartyDataFormatter.php
+++ b/inc/Data/ThirdPartyDataFormatter.php
@@ -89,19 +89,19 @@ class ThirdPartyDataFormatter
         }
         if (isset($newData['scripts']) && $newData['scripts']) {
             $newData['scripts'] = array_map(
-                static function ($scriptData) use ($allScriptParams, $scriptUrlParamInputs) {
+                static function ($scriptData) use ($args) {
                     if (isset($scriptData['url'])) {
                         $scriptData['url'] = self::formatUrl(
                             $scriptData['url'],
-                            $allScriptParams,
-                            $scriptUrlParamInputs,
+                            $scriptData['params'] ?? [],
+                            $args,
                             [],
                             $scriptData['optionalParams'] ?? []
                         );
                     } else {
                         $scriptData['code'] = self::formatCode(
                             $scriptData['code'],
-                            $scriptUrlParamInputs,
+                            $args,
                             $scriptData['optionalParams'] ?? []
                         );
                     }
@@ -195,19 +195,22 @@ class ThirdPartyDataFormatter
             }
         }
 
+        $queryArgs = [];
         if ($params && $args) {
             $queryArgs = self::intersectArgs($args, $params);
-            if ($optionalParams) {
-                $optionalArgs = self::intersectArgs($optionalParams, $params);
-                foreach ($optionalArgs as $k => $v) {
-                    if (!isset($queryArgs[$k])) {
-                        $queryArgs[$k] = $v;
-                    }
+        }
+        if ($optionalParams) {
+            foreach ($optionalParams as $k => $v) {
+                if (isset($args[$k])) {
+                    $queryArgs[$k] = $args[$k];
+                } elseif ($v) {
+                    $queryArgs[$k] = $v;
                 }
             }
-            if ($queryArgs) {
-                $url = self::setUrlQueryArgs($url, $queryArgs);
-            }
+        }
+
+        if ($queryArgs) {
+            $url = self::setUrlQueryArgs($url, $queryArgs);
         }
 
         return $url;

--- a/inc/Data/ThirdPartyDataFormatter.php
+++ b/inc/Data/ThirdPartyDataFormatter.php
@@ -234,7 +234,7 @@ class ThirdPartyDataFormatter
     ): string {
         // Conditionals.
         $code = preg_replace_callback(
-            '/{{#(.*?)}}(.*){{\/\1}}/',
+            '/{{#([^}]*?)}}(.*){{\/\1}}/',
             static function ($matches) use ($args, $optionalParams) {
                 if ((isset($args[ $matches[1] ]) && $args[ $matches[1] ]) ||
                     (isset($optionalParams[ $matches[1] ]) &&  $optionalParams[ $matches[1] ])) {

--- a/inc/Data/ThirdPartyDataFormatter.php
+++ b/inc/Data/ThirdPartyDataFormatter.php
@@ -234,7 +234,7 @@ class ThirdPartyDataFormatter
     ): string {
         // Conditionals.
         $code = preg_replace_callback(
-            '/{{#([^{}]*?)}}(.*){{\/\1}}/',
+            '/{{#([^{}]+?)}}(.*){{\/\1}}/',
             static function ($matches) use ($args, $optionalParams) {
                 if ((isset($args[ $matches[1] ]) && $args[ $matches[1] ]) ||
                     (isset($optionalParams[ $matches[1] ]) &&  $optionalParams[ $matches[1] ])) {

--- a/inc/Data/ThirdPartyDataFormatter.php
+++ b/inc/Data/ThirdPartyDataFormatter.php
@@ -234,7 +234,7 @@ class ThirdPartyDataFormatter
     ): string {
         // Conditionals.
         $code = preg_replace_callback(
-            '/{{#([^{}]+)}}(.*){{\/\1}}/',
+            '/{{#([^{}]+?)}}(.*){{\/\1}}/',
             static function ($matches) use ($args, $optionalParams) {
                 if ((isset($args[ $matches[1] ]) && $args[ $matches[1] ]) ||
                     (isset($optionalParams[ $matches[1] ]) &&  $optionalParams[ $matches[1] ])) {

--- a/inc/Data/ThirdPartyDataFormatter.php
+++ b/inc/Data/ThirdPartyDataFormatter.php
@@ -234,7 +234,7 @@ class ThirdPartyDataFormatter
     ): string {
         // Conditionals.
         $code = preg_replace_callback(
-            '/{{#([^}]*?)}}(.*){{\/\1}}/',
+            '/{{#([^{}]*?)}}(.*){{\/\1}}/',
             static function ($matches) use ($args, $optionalParams) {
                 if ((isset($args[ $matches[1] ]) && $args[ $matches[1] ]) ||
                     (isset($optionalParams[ $matches[1] ]) &&  $optionalParams[ $matches[1] ])) {

--- a/inc/Data/ThirdPartyDataFormatter.php
+++ b/inc/Data/ThirdPartyDataFormatter.php
@@ -234,7 +234,7 @@ class ThirdPartyDataFormatter
     ): string {
         // Conditionals.
         $code = preg_replace_callback(
-            '/{{#([^{}]+?)}}(.*){{\/\1}}/',
+            '/{{#([^{}]+)}}(.*){{\/\1}}/',
             static function ($matches) use ($args, $optionalParams) {
                 if ((isset($args[ $matches[1] ]) && $args[ $matches[1] ]) ||
                     (isset($optionalParams[ $matches[1] ]) &&  $optionalParams[ $matches[1] ])) {

--- a/inc/Data/ThirdPartyDataFormatter.php
+++ b/inc/Data/ThirdPartyDataFormatter.php
@@ -229,6 +229,20 @@ class ThirdPartyDataFormatter
         array $args,
         array $optionalParams = []
     ): string {
+        // Conditionals.
+        $code = preg_replace_callback(
+            '/{{#(.*?)}}(.*){{\/\1}}/',
+            static function ($matches) use ($args, $optionalParams) {
+                if ((isset($args[ $matches[1] ]) && $args[ $matches[1] ]) ||
+                    (isset($optionalParams[ $matches[1] ]) &&  $optionalParams[ $matches[1] ])) {
+                    return $matches[2];
+                }
+                return '';
+            },
+            $code
+        );
+
+        // Variables.
         return preg_replace_callback(
             '/{{([^}]+)}}/',
             static function ($matches) use ($args, $optionalParams) {

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -343,6 +343,38 @@ describe('Utils', () => {
         },
         output: `{"key":"value"}`,
       },
+      // conditional with true
+      {
+        input: 'Hello{{#name}} World{{/name}}',
+        params: {
+          name: 'World',
+        },
+        output: `Hello World`,
+      },
+      // conditional with false
+      {
+        input: 'Hello{{#name}} World{{/name}}',
+        params: {
+          name: null,
+        },
+        output: `Hello`,
+      },
+      // conditional with true including variable
+      {
+        input: 'Hello{{#name}} {{name}}{{/name}}, how are you?',
+        params: {
+          name: 'World',
+        },
+        output: `Hello World, how are you?`,
+      },
+      // conditional with false including variable
+      {
+        input: 'Hello{{#name}} {{name}}{{/name}}, how are you?',
+        params: {
+          name: null,
+        },
+        output: `Hello, how are you?`,
+      },
     ];
 
     it.each(inputs)(

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -365,7 +365,7 @@ describe('Utils', () => {
         params: {
           name: 'James',
         },
-        output: `window.func("setName", "James")`,
+        output: `window.func("setName", "James");`,
       },
       // conditional with false including variable
       {

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -345,35 +345,35 @@ describe('Utils', () => {
       },
       // conditional with true
       {
-        input: 'Hello{{#name}} World{{/name}}',
+        input: '{{#enabled}}window.func("enable", true);{{/enabled}}',
         params: {
-          name: 'World',
+          enabled: true,
         },
-        output: `Hello World`,
+        output: `window.func("enable", true);`,
       },
       // conditional with false
       {
-        input: 'Hello{{#name}} World{{/name}}',
+        input: '{{#enabled}}window.func("enable", true);{{/enabled}}',
         params: {
-          name: null,
+          enabled: false,
         },
-        output: `Hello`,
+        output: ``,
       },
       // conditional with true including variable
       {
-        input: 'Hello{{#name}} {{name}}{{/name}}, how are you?',
+        input: '{{#name}}window.func("setName", {{name}});{{/name}}',
         params: {
-          name: 'World',
+          name: 'James',
         },
-        output: `Hello World, how are you?`,
+        output: `window.func("setName", "James")`,
       },
       // conditional with false including variable
       {
-        input: 'Hello{{#name}} {{name}}{{/name}}, how are you?',
+        input: '{{#name}}window.func("setName", {{name}});{{/name}}',
         params: {
           name: null,
         },
-        output: `Hello, how are you?`,
+        output: ``,
       },
     ];
 

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -375,6 +375,14 @@ describe('Utils', () => {
         },
         output: ``,
       },
+      // conditional with too many braces (do not do that!)
+      {
+        input: '{{{#name}}}window.func("setName", {{name}});{{{/name}}}',
+        params: {
+          name: 'James',
+        },
+        output: `{}window.func("setName", "James");{}`,
+      },
     ];
 
     it.each(inputs)(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -61,12 +61,15 @@ export function formatCode(
   optionalParams?: Inputs,
 ) {
   // Conditionals.
-  code = code.replace(/{{#(.*?)}}(.*){{\/\1}}/g, (match, name, innerCode) => {
-    if (args?.[name] || optionalParams?.[name]) {
-      return innerCode;
-    }
-    return '';
-  });
+  code = code.replace(
+    /{{#([^}]*?)}}(.*){{\/\1}}/g,
+    (match, name, innerCode) => {
+      if (args?.[name] || optionalParams?.[name]) {
+        return innerCode;
+      }
+      return '';
+    },
+  );
 
   // Variable replacements.
   return code.replace(/{{[^#/](.*?)}}/g, (match) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -62,7 +62,7 @@ export function formatCode(
 ) {
   // Conditionals.
   code = code.replace(
-    /{{#([^{}]+?)}}(.*){{\/\1}}/g,
+    /{{#([^{}]+)}}(.*){{\/\1}}/g,
     (match, name, innerCode) => {
       if (args?.[name] || optionalParams?.[name]) {
         return innerCode;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -62,7 +62,7 @@ export function formatCode(
 ) {
   // Conditionals.
   code = code.replace(
-    /{{#([^{}]+)}}(.*){{\/\1}}/g,
+    /{{#([^{}]+?)}}(.*){{\/\1}}/g,
     (match, name, innerCode) => {
       if (args?.[name] || optionalParams?.[name]) {
         return innerCode;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -62,7 +62,7 @@ export function formatCode(
 ) {
   // Conditionals.
   code = code.replace(
-    /{{#([^{}]*?)}}(.*){{\/\1}}/g,
+    /{{#([^{}]+?)}}(.*){{\/\1}}/g,
     (match, name, innerCode) => {
       if (args?.[name] || optionalParams?.[name]) {
         return innerCode;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -62,7 +62,7 @@ export function formatCode(
 ) {
   // Conditionals.
   code = code.replace(
-    /{{#([^}]*?)}}(.*){{\/\1}}/g,
+    /{{#([^{}]*?)}}(.*){{\/\1}}/g,
     (match, name, innerCode) => {
       if (args?.[name] || optionalParams?.[name]) {
         return innerCode;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -54,7 +54,16 @@ export function formatCode(
   args?: Inputs,
   optionalParams?: Inputs,
 ) {
-  return code.replace(/{{(.*?)}}/g, (match) => {
+  // Conditionals.
+  code = code.replace(/{{#(.*?)}}(.*){{\/\1}}/g, (match, name, innerCode) => {
+    if (args?.[name] || optionalParams?.[name]) {
+      return innerCode;
+    }
+    return '';
+  });
+
+  // Variable replacements.
+  return code.replace(/{{[^#/](.*?)}}/g, (match) => {
     const name = match.split(/{{|}}/).filter(Boolean)[0];
     return JSON.stringify(
       args?.[name] !== undefined ? args?.[name] : optionalParams?.[name],

--- a/tests/phpunit/tests/Data/ThirdPartyDataFormatterTest.php
+++ b/tests/phpunit/tests/Data/ThirdPartyDataFormatterTest.php
@@ -405,6 +405,11 @@ class ThirdPartyDataFormatterTest extends TestCase
                 [ 'name' => null ],
                 '',
             ],
+            'too many braces' => [
+                '{{{#name}}}window.func("setName", {{name}});{{{/name}}}',
+                [ 'name' => 'James' ],
+                '{}window.func("setName", "James");{}',
+            ],
         ];
     }
 }

--- a/tests/phpunit/tests/Data/ThirdPartyDataFormatterTest.php
+++ b/tests/phpunit/tests/Data/ThirdPartyDataFormatterTest.php
@@ -372,4 +372,39 @@ class ThirdPartyDataFormatterTest extends TestCase
             $code
         );
     }
+
+    /**
+     * @dataProvider dataFormatCodeWithConditionals
+     */
+    public function testFormatCodeWithConditionals(string $input, array $params, string $expected)
+    {
+        $code = ThirdPartyDataFormatter::formatCode($input, $params);
+        $this->assertSame($expected, $code);
+    }
+
+    public function dataFormatCodeWithConditionals(): array
+    {
+        return [
+            'true'                => [
+                '{{#enabled}}window.func("enable", true);{{/enabled}}',
+                [ 'enabled' => true ],
+                'window.func("enable", true);',
+            ],
+            'false'               => [
+                '{{#enabled}}window.func("enable", true);{{/enabled}}',
+                [ 'enabled' => false ],
+                '',
+            ],
+            'true with variable'  => [
+                '{{#name}}window.func("setName", {{name}});{{/name}}',
+                [ 'name' => 'James' ],
+                'window.func("setName", "James");',
+            ],
+            'false with variable' => [
+                '{{#name}}window.func("setName", {{name}});{{/name}}',
+                [ 'name' => null ],
+                '',
+            ],
+        ];
+    }
 }

--- a/tests/phpunit/tests/ThirdParties/GoogleAnalyticsTest.php
+++ b/tests/phpunit/tests/ThirdParties/GoogleAnalyticsTest.php
@@ -42,7 +42,6 @@ class GoogleAnalyticsTest extends TestCase
 
     public function dataOutput(): array
     {
-        $consentDefault = '{"ad_user_data":"denied","ad_personalization":"denied","ad_storage":"denied","analytics_storage":"denied","wait_for_update":500}';
         return [
             'basic example'          => [
                 [ 'id' => 'G-12345678' ],
@@ -58,7 +57,7 @@ class GoogleAnalyticsTest extends TestCase
                         'strategy' => ThirdPartyScriptData::STRATEGY_WORKER,
                         'location' => ThirdPartyScriptData::LOCATION_HEAD,
                         'action'   => ThirdPartyScriptData::ACTION_APPEND,
-                        'code'     => "window[\"dataLayer\"]=window[\"dataLayer\"]||[];window['gtag-'+\"dataLayer\"]=function (){window[\"dataLayer\"].push(arguments);};window['gtag-'+\"dataLayer\"]('consent', \"default\", {$consentDefault});window['gtag-'+\"dataLayer\"]('js',new Date());window['gtag-'+\"dataLayer\"]('config',\"G-12345678\")",
+                        'code'     => "window[\"dataLayer\"]=window[\"dataLayer\"]||[];window['gtag-'+\"dataLayer\"]=function (){window[\"dataLayer\"].push(arguments);};window['gtag-'+\"dataLayer\"]('js',new Date());window['gtag-'+\"dataLayer\"]('config',\"G-12345678\")",
                         'key'      => 'setup',
                     ],
                 ],
@@ -80,7 +79,63 @@ class GoogleAnalyticsTest extends TestCase
                         'strategy' => ThirdPartyScriptData::STRATEGY_WORKER,
                         'location' => ThirdPartyScriptData::LOCATION_HEAD,
                         'action'   => ThirdPartyScriptData::ACTION_APPEND,
-                        'code'     => "window[\"myDataLayer1\"]=window[\"myDataLayer1\"]||[];window['gtag-'+\"myDataLayer1\"]=function (){window[\"myDataLayer1\"].push(arguments);};window['gtag-'+\"myDataLayer1\"]('consent', \"default\", {$consentDefault});window['gtag-'+\"myDataLayer1\"]('js',new Date());window['gtag-'+\"myDataLayer1\"]('config',\"G-13579\")",
+                        'code'     => "window[\"myDataLayer1\"]=window[\"myDataLayer1\"]||[];window['gtag-'+\"myDataLayer1\"]=function (){window[\"myDataLayer1\"].push(arguments);};window['gtag-'+\"myDataLayer1\"]('js',new Date());window['gtag-'+\"myDataLayer1\"]('config',\"G-13579\")",
+                        'key'      => 'setup',
+                    ],
+                ],
+            ],
+            'with default consent'   => [
+                [
+                    'id'            => 'G-12345678',
+                    'consentValues' => [
+                        'ad_user_data'        => 'denied',
+                        'ad_personalization'  => 'denied',
+                        'ad_storage'          => 'denied',
+                        'analytics_storage'   => 'denied',
+                        'wait_for_update'     => 500,
+                    ],
+                ],
+                [
+                    [
+                        'strategy' => ThirdPartyScriptData::STRATEGY_WORKER,
+                        'location' => ThirdPartyScriptData::LOCATION_HEAD,
+                        'action'   => ThirdPartyScriptData::ACTION_APPEND,
+                        'url'      => 'https://www.googletagmanager.com/gtag/js?id=G-12345678',
+                        'key'      => 'gtag',
+                    ],
+                    [
+                        'strategy' => ThirdPartyScriptData::STRATEGY_WORKER,
+                        'location' => ThirdPartyScriptData::LOCATION_HEAD,
+                        'action'   => ThirdPartyScriptData::ACTION_APPEND,
+                        'code'     => "window[\"dataLayer\"]=window[\"dataLayer\"]||[];window['gtag-'+\"dataLayer\"]=function (){window[\"dataLayer\"].push(arguments);};window['gtag-'+\"dataLayer\"]('consent', \"default\", {\"ad_user_data\":\"denied\",\"ad_personalization\":\"denied\",\"ad_storage\":\"denied\",\"analytics_storage\":\"denied\",\"wait_for_update\":500});window['gtag-'+\"dataLayer\"]('js',new Date());window['gtag-'+\"dataLayer\"]('config',\"G-12345678\")",
+                        'key'      => 'setup',
+                    ],
+                ],
+            ],
+            'with consent update'    => [
+                [
+                    'id'            => 'G-12345678',
+                    'consentType'   => 'update',
+                    'consentValues' => [
+                        'ad_user_data'        => 'granted',
+                        'ad_personalization'  => 'granted',
+                        'ad_storage'          => 'granted',
+                        'analytics_storage'   => 'granted',
+                    ],
+                ],
+                [
+                    [
+                        'strategy' => ThirdPartyScriptData::STRATEGY_WORKER,
+                        'location' => ThirdPartyScriptData::LOCATION_HEAD,
+                        'action'   => ThirdPartyScriptData::ACTION_APPEND,
+                        'url'      => 'https://www.googletagmanager.com/gtag/js?id=G-12345678',
+                        'key'      => 'gtag',
+                    ],
+                    [
+                        'strategy' => ThirdPartyScriptData::STRATEGY_WORKER,
+                        'location' => ThirdPartyScriptData::LOCATION_HEAD,
+                        'action'   => ThirdPartyScriptData::ACTION_APPEND,
+                        'code'     => "window[\"dataLayer\"]=window[\"dataLayer\"]||[];window['gtag-'+\"dataLayer\"]=function (){window[\"dataLayer\"].push(arguments);};window['gtag-'+\"dataLayer\"]('consent', \"update\", {\"ad_user_data\":\"granted\",\"ad_personalization\":\"granted\",\"ad_storage\":\"granted\",\"analytics_storage\":\"granted\"});window['gtag-'+\"dataLayer\"]('js',new Date());window['gtag-'+\"dataLayer\"]('config',\"G-12345678\")",
                         'key'      => 'setup',
                     ],
                 ],


### PR DESCRIPTION
In regards to https://github.com/GoogleChromeLabs/third-party-capital/pull/71#issuecomment-2332572666: This is a _very simplistic_ (!) attempt at supporting conditionals in the templating system.

It allows using Mustache-like conditionals, e.g.
```
{{#consentValues}}window['gtag-'+{{l}}]('consent', {{consentType}}, {{consentValues}});{{/consentValues}}
```

We could use that to enhance the solution from #71, making `consentValues` null by default, so that the call is only made if this is specified. In light of not supporting more complicated conditionals, it would make sense to leave "default" as the default value for `consentType`, as the more important piece of information to provide for such calls is the configuration object anyway.

It probably has several limitations e.g. when it comes to having multiple conditional clauses of the same name in one code snippet etc., but as long as we're aware of that limitation, maybe this is an okay start for now? There are certainly more reliable and established solutions out there, but for those it would probably make more sense to pull in a library, which requires more discussion. So maybe this works? :)

(My first JS PR in this codebase, so let's see if I got things right.)