### PR TITLE
refactor utils

### DIFF
--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -21,7 +21,6 @@ describe('Utils', () => {
       const args = {
         unit: 'imperial',
       };
-      const optionalParamKeys = ['type'];
       const optionalParams = {
         type: 'main',
       };
@@ -31,7 +30,6 @@ describe('Utils', () => {
         requiredParams,
         args,
         undefined,
-        optionalParamKeys,
         optionalParams,
       );
       expect(newUrl).toEqual('https://example.com/?unit=imperial&type=main');
@@ -330,7 +328,7 @@ describe('Utils', () => {
         params: {
           val: null,
         },
-        output: `null`,
+        output: `undefined`,
       },
       // undefined
       {

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -21,6 +21,7 @@ describe('Utils', () => {
       const args = {
         unit: 'imperial',
       };
+      const optionalParamKeys = ['type'];
       const optionalParams = {
         type: 'main',
       };
@@ -30,6 +31,7 @@ describe('Utils', () => {
         requiredParams,
         args,
         undefined,
+        optionalParamKeys,
         optionalParams,
       );
       expect(newUrl).toEqual('https://example.com/?unit=imperial&type=main');

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -111,17 +111,6 @@ export function createHtml(
 
 // Format JSON by including all default and user-required parameters
 export function formatData(data: Data, args: Inputs): Output {
-  const allScriptParams = data.scripts?.reduce(
-    (acc, script) => [
-      ...acc,
-      ...(Array.isArray(script.params) ? script.params : []),
-    ],
-    [] as string[],
-  );
-
-  // First, find all input arguments that map to parameters passed to script URLs
-  const scriptUrlParamInputs = filterArgs(args, allScriptParams);
-
   // Second, find all input arguments that map to parameters passed to the HTML src attribute
   const htmlUrlParamInputs = filterArgs(
     args,
@@ -136,11 +125,7 @@ export function formatData(data: Data, args: Inputs): Output {
   // Lastly, all remaining arguments are forwarded as separate HTML attributes
   const htmlAttrInputs = filterArgs(
     args,
-    [
-      ...Object.keys(scriptUrlParamInputs),
-      ...Object.keys(htmlUrlParamInputs),
-      ...Object.keys(htmlSlugParamInput),
-    ],
+    [...Object.keys(htmlUrlParamInputs), ...Object.keys(htmlSlugParamInput)],
     true,
   );
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -152,9 +152,9 @@ export function formatData(data: Data, args: Inputs): Output {
             : [];
 
           // if we're receiving undefined or null as an ar, we check the optionalParams
-          const newArgs: any = {};
+          const newArgs: any = { ...script.optionalParams };
           Object.keys(args).forEach((key) => {
-            newArgs[key] = args[key] || script.optionalParams?.[key];
+            if (args[key]) newArgs[key] = args[key];
           });
           const optionalParamInputs = filterArgs(newArgs, optionalParamKeys);
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -116,6 +116,7 @@ export function formatData(data: Data, args: Inputs): Output {
     (acc, script) => [
       ...acc,
       ...(Array.isArray(script.params) ? script.params : []),
+      ...(script.optionalParams ? Object.keys(script.optionalParams) : []),
     ],
     [] as string[],
   );

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -112,6 +112,17 @@ export function createHtml(
 
 // Format JSON by including all default and user-required parameters
 export function formatData(data: Data, args: Inputs): Output {
+  const allScriptParams = data.scripts?.reduce(
+    (acc, script) => [
+      ...acc,
+      ...(Array.isArray(script.params) ? script.params : []),
+    ],
+    [] as string[],
+  );
+
+  // First, find all input arguments that map to parameters passed to script URLs
+  const scriptUrlParamInputs = filterArgs(args, allScriptParams);
+
   // Second, find all input arguments that map to parameters passed to the HTML src attribute
   const htmlUrlParamInputs = filterArgs(
     args,
@@ -126,7 +137,11 @@ export function formatData(data: Data, args: Inputs): Output {
   // Lastly, all remaining arguments are forwarded as separate HTML attributes
   const htmlAttrInputs = filterArgs(
     args,
-    [...Object.keys(htmlUrlParamInputs), ...Object.keys(htmlSlugParamInput)],
+    [
+      ...Object.keys(scriptUrlParamInputs),
+      ...Object.keys(htmlUrlParamInputs),
+      ...Object.keys(htmlSlugParamInput),
+    ],
     true,
   );
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -62,6 +62,7 @@ export function formatCode(
 ) {
   return code.replace(/{{(.*?)}}/g, (match) => {
     const name = match.split(/{{|}}/).filter(Boolean)[0];
+
     return JSON.stringify(
       paramInputs?.[name] !== undefined
         ? paramInputs?.[name]
@@ -149,7 +150,13 @@ export function formatData(data: Data, args: Inputs): Output {
           const optionalParamKeys = script.optionalParams
             ? Object.keys(script.optionalParams)
             : [];
-          const optionalParamInputs = filterArgs(args, optionalParamKeys);
+
+          // if we're receiving undefined or null as an ar, we check the optionalParams
+          const newArgs: any = {};
+          Object.keys(args).forEach((key) => {
+            newArgs[key] = args[key] || script.optionalParams?.[key];
+          });
+          const optionalParamInputs = filterArgs(newArgs, optionalParamKeys);
 
           return isExternalScript(script)
             ? {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -27,28 +27,28 @@ function filterArgs(
 // Add all required search params with user inputs as values
 export function formatUrl(
   url: string,
-  paramKeys?: string[],
-  paramInputs?: Inputs,
+  params?: string[],
+  args?: Inputs,
   slug?: Inputs,
-  optionalParamKeys?: string[],
-  optionalParamInputs?: Inputs,
+  optionalParams?: Inputs,
 ) {
   const newUrl =
     slug && Object.keys(slug).length > 0
       ? new URL(Object.values(slug)[0], url) // If there's a user inputted param for the URL slug, replace the default existing slug or include it
       : new URL(url);
 
-  if (paramKeys && paramInputs) {
-    paramKeys.forEach((param: string) => {
-      if (paramInputs[param])
-        newUrl.searchParams.set(param, paramInputs[param]);
+  if (params && args) {
+    params.forEach((param: string) => {
+      if (args[param]) newUrl.searchParams.set(param, args[param]);
     });
   }
 
-  if (optionalParamKeys && optionalParamInputs) {
-    optionalParamKeys.forEach((param: string) => {
-      if (optionalParamInputs[param])
-        newUrl.searchParams.set(param, optionalParamInputs[param]);
+  if (optionalParams) {
+    Object.keys(optionalParams).forEach((key: string) => {
+      if (args?.[key]) newUrl.searchParams.set(key, args[key]);
+      else if (optionalParams[key]) {
+        newUrl.searchParams.set(key, optionalParams[key]);
+      }
     });
   }
 
@@ -57,17 +57,13 @@ export function formatUrl(
 
 export function formatCode(
   code: string,
-  paramInputs?: Inputs,
-  optionalParamInputs?: Inputs,
+  args?: Inputs,
+  optionalParams?: Inputs,
 ) {
   return code.replace(/{{(.*?)}}/g, (match) => {
     const name = match.split(/{{|}}/).filter(Boolean)[0];
 
-    return JSON.stringify(
-      paramInputs?.[name] !== undefined
-        ? paramInputs?.[name]
-        : optionalParamInputs?.[name],
-    );
+    return JSON.stringify(args?.[name] ?? optionalParams?.[name] ?? undefined);
   });
 }
 
@@ -161,34 +157,20 @@ export function formatData(data: Data, args: Inputs): Output {
     // Pass any required query params with user values for relevant scripts
     scripts: data.scripts
       ? data.scripts.map((script) => {
-          const paramKeys = script.params;
-          const paramInputs = filterArgs(args, paramKeys);
-          const optionalParamKeys = script.optionalParams
-            ? Object.keys(script.optionalParams)
-            : [];
-
-          // if we're receiving undefined or null as an ar, we check the optionalParams
-          const newArgs: any = { ...script.optionalParams };
-          Object.keys(args).forEach((key) => {
-            if (args[key]) newArgs[key] = args[key];
-          });
-          const optionalParamInputs = filterArgs(newArgs, optionalParamKeys);
-
           return isExternalScript(script)
             ? {
                 ...script,
                 url: formatUrl(
                   script.url,
-                  paramKeys,
-                  paramInputs,
+                  script.params,
+                  args,
                   undefined,
-                  optionalParamKeys,
-                  optionalParamInputs,
+                  script.optionalParams,
                 ),
               }
             : {
                 ...script,
-                code: formatCode(script.code, paramInputs, optionalParamInputs),
+                code: formatCode(script.code, args, script.optionalParams),
               };
         })
       : undefined,


### PR DESCRIPTION
only use params and optional params for each script, instead of combining them all.

This still relies on the optional templating option that @felixarntz is working on.

behavior that we want (i think):
- params override optional params (unless param values are null'isch)
- optional params get assigned (unless optional param values are null'isch)
