### PR TITLE
Ensure PHPUnit tests are run when third party JSON files are changed

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -7,6 +7,7 @@ on:
     # Only run if PHP-related files changed.
     paths:
       - '.github/workflows/php-test.yml'
+      - 'data/*.json'
       - '**.php'
       - 'phpunit.xml.dist'
       - 'composer.json'
@@ -17,6 +18,7 @@ on:
     # Only run if PHP-related files changed.
     paths:
       - '.github/workflows/php-test.yml'
+      - 'data/*.json'
       - '**.php'
       - 'phpunit.xml.dist'
       - 'composer.json'


### PR DESCRIPTION
This addresses https://github.com/GoogleChromeLabs/third-party-capital/pull/72#pullrequestreview-2301545505.

Without this, we won't know about PHPUnit test failures due to changing the JSON files, which is critical.