### PR TITLE
chore: improve analytics types and optional params

### DIFF
--- a/data/google-analytics.json
+++ b/data/google-analytics.json
@@ -19,8 +19,7 @@
       "params": ["id"],
       "optionalParams": {
         "l": "dataLayer",
-        "consentType": "default",
-        "consentValues": null
+        "consentType": "default"
       },
       "strategy": "worker",
       "location": "head",

--- a/src/types/type-declarations.ts
+++ b/src/types/type-declarations.ts
@@ -74,7 +74,6 @@ export interface GoogleAnalyticsParams {
   consentType?: string;
   /**
    * Consent values for Google Analytics.
-   * @default {{"ad_user_data":"denied","ad_personalization":"denied","ad_storage":"denied","analytics_storage":"denied","wait_for_update":500}}
    */
   consentValues?: { [key: string]: string };
 }


### PR DESCRIPTION
hey :wave: here's some slights improvement for GA

We can remove the JS docs for the default value of consentValues. We can also remove consentValues from the optionalParams since undefined should be falsy by default

cc @felixarntz 