### PR TITLE
Add PHPUnit test cases for Tag Manager consent mode

### DIFF
--- a/data/google-tag-manager.json
+++ b/data/google-tag-manager.json
@@ -15,7 +15,7 @@
         "key": "gtm"
       },
       {
-        "code": "window[{{l}}]=window[{{l}}]||[];{{#consentValues}}(function () {window[{{l}}].push(arguments)})('consent', {{consentType}},{{consentValues}});{{/consentValues}}window[{{l}}].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
+        "code": "window[{{l}}]=window[{{l}}]||[];{{#consentValues}}(function () {window[{{l}}].push(arguments)})('consent', {{consentType}}, {{consentValues}});{{/consentValues}}window[{{l}}].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
         "optionalParams": {
           "l": "dataLayer",
           "consentType": "default",

--- a/tests/phpunit/tests/ThirdParties/GoogleTagManagerTest.php
+++ b/tests/phpunit/tests/ThirdParties/GoogleTagManagerTest.php
@@ -84,6 +84,62 @@ class GoogleTagManagerTest extends TestCase
                     ],
                 ],
             ],
+            'with default consent'   => [
+                [
+                    'id'            => 'GTM-12345678',
+                    'consentValues' => [
+                        'ad_user_data'        => 'denied',
+                        'ad_personalization'  => 'denied',
+                        'ad_storage'          => 'denied',
+                        'analytics_storage'   => 'denied',
+                        'wait_for_update'     => 500,
+                    ],
+                ],
+                [
+                    [
+                        'strategy' => ThirdPartyScriptData::STRATEGY_WORKER,
+                        'location' => ThirdPartyScriptData::LOCATION_HEAD,
+                        'action'   => ThirdPartyScriptData::ACTION_APPEND,
+                        'url'      => 'https://www.googletagmanager.com/gtm.js?id=GTM-12345678',
+                        'key'      => 'gtm',
+                    ],
+                    [
+                        'strategy' => ThirdPartyScriptData::STRATEGY_WORKER,
+                        'location' => ThirdPartyScriptData::LOCATION_HEAD,
+                        'action'   => ThirdPartyScriptData::ACTION_APPEND,
+                        'code'     => "window[\"dataLayer\"]=window[\"dataLayer\"]||[];(function () {window[\"dataLayer\"].push(arguments)})('consent', \"default\", {\"ad_user_data\":\"denied\",\"ad_personalization\":\"denied\",\"ad_storage\":\"denied\",\"analytics_storage\":\"denied\",\"wait_for_update\":500});window[\"dataLayer\"].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
+                        'key'      => 'setup',
+                    ],
+                ],
+            ],
+            'with consent update'    => [
+                [
+                    'id'            => 'GTM-12345678',
+                    'consentType'   => 'update',
+                    'consentValues' => [
+                        'ad_user_data'        => 'granted',
+                        'ad_personalization'  => 'granted',
+                        'ad_storage'          => 'granted',
+                        'analytics_storage'   => 'granted',
+                    ],
+                ],
+                [
+                    [
+                        'strategy' => ThirdPartyScriptData::STRATEGY_WORKER,
+                        'location' => ThirdPartyScriptData::LOCATION_HEAD,
+                        'action'   => ThirdPartyScriptData::ACTION_APPEND,
+                        'url'      => 'https://www.googletagmanager.com/gtm.js?id=GTM-12345678',
+                        'key'      => 'gtm',
+                    ],
+                    [
+                        'strategy' => ThirdPartyScriptData::STRATEGY_WORKER,
+                        'location' => ThirdPartyScriptData::LOCATION_HEAD,
+                        'action'   => ThirdPartyScriptData::ACTION_APPEND,
+                        'code'     => "window[\"dataLayer\"]=window[\"dataLayer\"]||[];(function () {window[\"dataLayer\"].push(arguments)})('consent', \"update\", {\"ad_user_data\":\"granted\",\"ad_personalization\":\"granted\",\"ad_storage\":\"granted\",\"analytics_storage\":\"granted\"});window[\"dataLayer\"].push({'gtm.start':new Date().getTime(),event:'gtm.js'});",
+                        'key'      => 'setup',
+                    ],
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
Follow up to #72:
* Add PHPUnit tests for new consent mode code in Tag Manager.
* Add a missing space to the code template for consistency (doesn't change any existing behaviors or tests).